### PR TITLE
added filter for deprecated MITRE objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ INFO:utils.queries:
 INFO:utils.queries:Total groups 4
 
 ```
-If fewer TTPs are supplied, then there's a greater chance to map TTPs to many more threat groups. For example, just looking at T1189 results in 24 different threat groups:
+If fewer TTPs are supplied, then there's a greater chance to map TTPs to many more threat groups. 
+For example, just looking at T1189 results in 24 different threat groups:
 
 ```
 python explorer.py --infer_group --ttp T1189
@@ -172,11 +173,62 @@ python explorer.py --infer_group --ttp T1189
 The same command will also check if a TTP exists in TypeDB CTI. In this example, T1234 doesn't exist:
 ```
 python explorer.py --infer_group --ttp T1234
+
 ```
 In this case, the Explorer Utility throws the following error: 
 
 ```
 ERROR:utils.queries:TTP T1234 not in database
+```
+
+It is very important to understand the associations.
+For example this query:
+
+```
+python explorer.py --infer_group --ttp T1189 T1068
+```
+
+Returns 5 groups including APT32.
+
+But if you include the general technique T1222:
+```
+python explorer.py --infer_group --ttp T1189 T1068 T1222
+```
+There are no groups. But specify the right sub tecnique:
+
+```
+python explorer.py --infer_group --ttp T1189 T1068 T1222.002
+```
+
+And you wil find that APT32 is the only threat group possible.
+
+You can get basic information about a technique:
+```
+python explorer.py -get_info -ttp T1548
+```
+
+```
+INFO:utils.queries:
++-------+-----------------------------------+--------------------------+--------------------------+
+| TTP   | name                              | created                  | modified                 |
++=======+===================================+==========================+==========================+
+| T1548 | Abuse Elevation Control Mechanism | 2020-01-30T13:58:14.373Z | 2022-05-11T14:00:00.188Z |
++-------+-----------------------------------+--------------------------+--------------------------+
+```
+
+or of a sub technique:
+
+```
+python explorer.py -get_info -ttp T1548.001
+```
+
+```
+INFO:utils.queries:
++-----------+-------------------+--------------------------+--------------------------+
+| TTP       | name              | created                  | modified                 |
++===========+===================+==========================+==========================+
+| T1548.001 | Setuid and Setgid | 2020-01-30T14:11:41.212Z | 2022-05-11T14:00:00.188Z |
++-----------+-------------------+--------------------------+--------------------------+
 ```
 
 ### General Statistics of Key Entities
@@ -185,6 +237,7 @@ The Explorer Utility also provides the ability to display general information ab
 ```
 python explorer.py --stats
 ```
+
 This command will list the number of instances for a few key entity types: 
 
 ```
@@ -194,6 +247,43 @@ INFO:utils.queries:Total Mitre Techniques 659
 INFO:utils.queries:Total Mitre Sub Techniques 767
 INFO:utils.queries:Total Malware 577
 INFO:utils.queries:Total Tools 75
+```
+
+### Unique techniques associated to intrusion sets
+
+This is a very good metric to assess how a TTP can refer to only one Intrusion Set.
+
+```
+python explorer.py --ttp_scores --limit 2 --sort as
+```
+
+```
+INFO:utils.queries:
++-------+--------------------+
+| TTP   |   Intrusion counts |
++=======+====================+
+| T1218 |                  1 |
++-------+--------------------+
+| T1621 |                  1 |
++-------+--------------------+
+
+```
+
+And viceversa which ones are more widely used.
+
+```
+python explorer.py --ttp_scores --limit 2 --sort desc
+```
+
+```
+INFO:utils.queries:
++-------+--------------------+
+| TTP   |   Intrusion counts |
++=======+====================+
+| T1105 |                 69 |
++-------+--------------------+
+| T1027 |                 67 |
++-------+--------------------+
 ```
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ ERROR:utils.queries:TTP T1234 not in database
 ```
 
 It is very important to understand the associations.
-For example this query:
+
+For example, this query:
 
 ```
 python explorer.py --infer_group --ttp T1189 T1068
@@ -190,19 +191,20 @@ python explorer.py --infer_group --ttp T1189 T1068
 
 Returns 5 groups including APT32.
 
-But if you include the general technique T1222:
+But when including the general technique T1222:
 ```
 python explorer.py --infer_group --ttp T1189 T1068 T1222
 ```
-There are no groups. But specify the right sub tecnique:
+No groups are returned. However, if the right sub-technique is specified: 
 
 ```
 python explorer.py --infer_group --ttp T1189 T1068 T1222.002
 ```
 
-And you wil find that APT32 is the only threat group possible.
+APT32 is returned as the only possible threat group. 
 
-You can get basic information about a technique:
+Basic information about a technique can be obtained with this command: 
+
 ```
 python explorer.py -get_info -ttp T1548
 ```
@@ -216,7 +218,7 @@ INFO:utils.queries:
 +-------+-----------------------------------+--------------------------+--------------------------+
 ```
 
-or of a sub technique:
+Basic information of a sub-technique is returned with:
 
 ```
 python explorer.py -get_info -ttp T1548.001

--- a/migrate.py
+++ b/migrate.py
@@ -35,13 +35,23 @@ parser.add_argument('--data-path', dest='data_path', default='data/mitre', help=
 parser.add_argument('--clean', dest='clean', default=False, action="store_true",
                     help='Delete existing database if it exists before loading.')
 
+parser.add_argument('--mitre_deprecated', dest='ignore_deprecated_mitre', default=False, action="store_true",
+                    help='Delete existing database if it exists before loading.')
+
 args = parser.parse_args()
 logging.basicConfig(level=logging.INFO)  # when debugging, set to logging.DEBUG
 
 start = timer()
 initialise_database(args.uri, args.database, args.clean)
+
+if args.ignore_deprecated_mitre:
+    print(f"Ignoring mitre deprecated objects...")
+    ignore_conditions=[{'x_mitre_deprecated':True}]
+else:
+    ignore_conditions = []
+
 migrator = StixMigrator(args.uri, args.database, args.batch_size, args.threads)
-migrator.migrate(data_path=args.data_path)
+migrator.migrate(data_path=args.data_path,ignore_conditions=ignore_conditions)
 migrator.close()
 end = timer()
 time_in_sec = end - start

--- a/migrate.py
+++ b/migrate.py
@@ -32,11 +32,9 @@ parser.add_argument('--database', dest='database', default='cti', help='Database
 parser.add_argument('--batch_size', dest='batch_size', default=50, help='Transaction batch size during migration')
 parser.add_argument('--threads', dest='threads', default=16, help='Number of loading threads  with (recommend 2*cores)')
 parser.add_argument('--data-path', dest='data_path', default='data/mitre', help='Path to STIX-compliant data files')
-parser.add_argument('--clean', dest='clean', default=False, action="store_true",
-                    help='Delete existing database if it exists before loading.')
-
-parser.add_argument('--mitre_deprecated', dest='ignore_deprecated_mitre', default=False, action="store_true",
-                    help='Delete existing database if it exists before loading.')
+parser.add_argument('--clean', dest='clean', default=False, help='Delete existing database if it exists before loading.')
+parser.add_argument('--mitre_deprecated', dest='ignore_deprecated_mitre', default=False,
+						help='Set this flag to True to ignore objects with x_mitre_deprecated set to True.')
 
 args = parser.parse_args()
 logging.basicConfig(level=logging.INFO)  # when debugging, set to logging.DEBUG
@@ -44,11 +42,11 @@ logging.basicConfig(level=logging.INFO)  # when debugging, set to logging.DEBUG
 start = timer()
 initialise_database(args.uri, args.database, args.clean)
 
-if args.ignore_deprecated_mitre:
-    print(f"Ignoring mitre deprecated objects...")
+if args.ignore_deprecated_mitre == "True":
+    print(f"Ignoring objects with x_mitre_deprecated set to True...")
     ignore_conditions=[{'x_mitre_deprecated':True}]
 else:
-    ignore_conditions = []
+	ignore_conditions = []
 
 migrator = StixMigrator(args.uri, args.database, args.batch_size, args.threads)
 migrator.migrate(data_path=args.data_path,ignore_conditions=ignore_conditions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 typedb-client==2.9.0
 networkx[default]
 tabulate
+pandas

--- a/stix/migrator.py
+++ b/stix/migrator.py
@@ -31,12 +31,12 @@ class StixMigrator:
     def __init__(self, typedb_uri, database, batch_size, num_threads):
         self.inserter = TypeDBInserter(typedb_uri, database, batch_size=batch_size, num_threads=num_threads)
 
-    def migrate(self, data_path):
+    def migrate(self, data_path, ignore_conditions=[]):
         print('.....')
         print('Inserting data...')
         print('.....')
         stix_json_objects = self._read_stix_objects_json(data_path)
-        insert_generator = StixInsertGenerator(stix_json_objects)
+        insert_generator = StixInsertGenerator(stix_json_objects,ignore_conditions)
         self._migrate_stix_objects(insert_generator)
         self._migrate_stix_relationships(insert_generator)
         self._migrate_kill_chain_phases(insert_generator)

--- a/stix/query.py
+++ b/stix/query.py
@@ -81,15 +81,18 @@ class StixInsertGenerator:
             stix_object_type = stix_object['type']
 
             skip_check = False
-            #skip the object if if deprecated which is default behaviour
+            # Don't insert the the object if it's deprecated. Default behaviour is that deprecated objects get loaded.
             for check in self.ignore_conditions:
                 # atomic filter check
                 conditions = []
                 for attr_name in check.keys():
+                    # if mitre_deprecated is set to "true", then "attr_name" will be "x_mitre_deprecated"
+                    print(attr_name)
                     if attr_name in stix_object:
+                        print(check)
                         atom_check = stix_object[attr_name] == check[attr_name]
                         conditions.append(atom_check)
-                # we can skip the entire object
+                # if stix_object includes "x_mitre_deprecated=True", so we can skip the entire object
                 if all(conditions): 
                     
                     skip_check = True

--- a/stix/query.py
+++ b/stix/query.py
@@ -30,8 +30,9 @@ def sanitise_string(string_value):
 
 class StixInsertGenerator:
 
-    def __init__(self, stix_objects_json):
+    def __init__(self, stix_objects_json,ignore_conditions):
         self.stix_objects_json = stix_objects_json
+        self.ignore_conditions = ignore_conditions
 
     def referenced_stix_objects(self):
         referenced_ids = set()
@@ -75,9 +76,29 @@ class StixInsertGenerator:
     def stix_objects_and_marking_relations(self, exclude_ids):
         stix_entity_queries = set()
         stix_objects_with_marking_refs = []
-
+        ignored = []
         for stix_object in self.stix_objects_json:
             stix_object_type = stix_object['type']
+
+            skip_check = False
+            #skip the object if if deprecated which is default behaviour
+            for check in self.ignore_conditions:
+                # atomic filter check
+                conditions = []
+                for attr_name in check.keys():
+                    if attr_name in stix_object:
+                        atom_check = stix_object[attr_name] == check[attr_name]
+                        conditions.append(atom_check)
+                # we can skip the entire object
+                if all(conditions): 
+                    
+                    skip_check = True
+                    break
+            
+            if skip_check: 
+                ignored.append(stix_object['id'])
+                continue
+
             if stix_object_type != "relationship" and not stix_object['id'] in exclude_ids:
                 stix_type = stix_entity_to_typedb(stix_object_type)
                 if not stix_type['ignore']:
@@ -104,6 +125,7 @@ class StixInsertGenerator:
         marking_relations_queries = self._markings_relations(stix_objects_with_marking_refs)
         logging.debug(f"Generated {len(stix_entity_queries)} insert queries for stix entities")
         logging.debug(f"Generated {len(marking_relations_queries)} insert queries for marking relations")
+        print(f"Skipped {len(ignored)} objects based on conditions")
         return {
             "stix_entities": stix_entity_queries,
             "marking_relations": marking_relations_queries

--- a/utils/queries.py
+++ b/utils/queries.py
@@ -133,7 +133,7 @@ class TiExplorer:
 
                     self._subttp[ttp_id]=attack_name
 
-    def get_ttp_info(self,ttp_list:list):
+    def get_ttp_info(self,ttp_list:list,labels=['name']):
         with self.client.session(self.database, SessionType.DATA) as session:
             ## get various count stats
             with session.transaction(TransactionType.READ) as read_transaction:
@@ -141,18 +141,6 @@ class TiExplorer:
                 data = []
                 for ttp_id in ttp_list:
                     
-                    '''
-                    q_ttp = f'match\
-                            $exref isa external-reference, has source-name "mitre-attack", has external-id "{ttp_id}";\
-                            $ap isa attack-pattern, has name $n,has description $d, has revoked $r;\
-                            $rel (referencing: $ap, referenced: $exref) isa external-referencing;\
-                            get $n,$d,$r;'
-
-                    answer_iterator = read_transaction.query().match(q_ttp)
-                    print(q_ttp)
-                    for q in answer_iterator:
-                        data.append([ttp_id,q.get('n').get_value(),q.get('d').get_value(),q.get('r').get_value()])
-                    '''
                     q_ttp = f'match\
                             $exref isa external-reference, has source-name "mitre-attack", has external-id "{ttp_id}";\
                             $ap isa attack-pattern;\
@@ -163,15 +151,12 @@ class TiExplorer:
 
                     for q in answer_iterator:
                         ap = q.get('ap')
-                        ap_r = ap.as_remote(read_transaction)
-                        print(ap.get_type())
-
+                        attr_dict = {}
                         attrs = ap.as_remote(read_transaction).get_has()
                         for x in attrs:
-                            print(x.label)
-                            print(x.get_value())
-                        break
-                
+                            attr_dict[str(x.get_type().get_label())]=str(x.get_value())             
+                        data.append(attr_dict)
+                logger.info(data[0])
                 #logger.info('\n'+tabulate(data, ["TTP ID", "Name", "Description", "Revoked"], tablefmt="grid"))    
 
 


### PR DESCRIPTION
This is a good compromise as we don't change the structure but just ignore deprecated MITRE STIX objects at load time.
There is a commandline flag so the behaviour can be disabled.
We can think of a better long term solution later.